### PR TITLE
Campsite data parser

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -6,7 +6,6 @@ export interface Location {
 export interface Campsite {
   title: string,
   location: Location,
+  groupSite: boolean,
   datesAvailable: string[],
-  elevation: string,
-  detailsLink: string
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,19 +15,31 @@ app.use(cors(options));
 // Parse campsites data file
 let campsites:Campsite[] = [];
 
+function isDuplicate(uniqueCampsites:Campsite[], rawSite:any) {
+  return uniqueCampsites.find(campsite => {
+    return campsite.title === rawSite.properties.Campsite;
+  });
+}
+
 readFile('./raw_data/Backcountry_Campsites_for_2017.geojson', {encoding: 'utf-8'})
   .then(fileContents => {
     const rawSites = JSON.parse(fileContents).features as any[];
-    campsites = rawSites.map(rawSite => {
-      const siteProperties = rawSite.properties;
-      const groupSiteBoolean = siteProperties.GroupSite === "Yes" ? true : false;
-      return {
-        title: siteProperties.Campsite,
-        groupSite: groupSiteBoolean,
-        location: {lat: siteProperties.WGS84_LAT_DD ,long: siteProperties.WGS84_LON_DD},
-        datesAvailable: []
-      };
-    })
+
+    // iterate over the raw campsite data
+    campsites = rawSites.reduce((uniqueCampsites, rawSite) => {
+      if (!isDuplicate(uniqueCampsites, rawSite)) {
+        const siteProperties = rawSite.properties;
+        const groupSiteBoolean = siteProperties.GroupSite === "Yes" ? true : false;
+
+        uniqueCampsites.push({
+          title: siteProperties.Campsite,
+          groupSite: groupSiteBoolean,
+          location: {lat: siteProperties.WGS84_LAT_DD ,long: siteProperties.WGS84_LON_DD},
+          datesAvailable: []
+        });
+      }
+      return uniqueCampsites;
+    }, []);
   })
   .catch(err => console.error('Error reading campsites data file:', err));
 


### PR DESCRIPTION
Parse campsite JSON data from: https://romo-nps.opendata.arcgis.com/datasets/backcountry-campsites-for-2017/explore?location=40.355888%2C-105.698832%2C11.00

There are campsites with the same name, but slightly different lat-long coordinates because there can be multiple tent sites at a single campsite. Because the RMNP availability PDF does not say which tent site is booked/available and only says how many tent sites are available, the campsite was reduced to a single campsite and there will eventually be logic to know how many tent sites are available for that single campsite.

Closes #4 